### PR TITLE
Fix broken link for towers_of_hanoi

### DIFF
--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -38,7 +38,7 @@
   
 * [Math](math)
   * [russian peasant](math/russian_peasant)
-  * [towers of hanoi](math/towers_of_hanoi)
+  * [towers of hanoi](math/towers_of_Hanoi)
   * [Sieve of Eratosthenes](math/sieve%20of%20eratosthenes)
   * [armstrong number](math/armstrong_number)
   * [euclid's gcd](math/euclids_gcd)


### PR DESCRIPTION
The link text should be towers_of_Hanoi. Old one linked to towers_of_hanoi


